### PR TITLE
上向きの筆画のポリゴンが壊れるのを修正

### DIFF
--- a/kagecd.js
+++ b/kagecd.js
@@ -160,7 +160,11 @@ function cdDrawCurveU(kage, polygons, x1, y1, sx1, sy1, sx2, sy2, x2, y2, ta1, t
             ib = Math.cos(ir) * (kMinWidthT);
           }
           else if(ix == 0){
-            ia = kMinWidthT;
+            if (iy < 0) {
+              ia = -kMinWidthT;
+            } else {
+              ia = kMinWidthT;
+            }
             ib = 0;
           }
           else{
@@ -267,7 +271,11 @@ function cdDrawCurveU(kage, polygons, x1, y1, sx1, sy1, sx2, sy2, x2, y2, ta1, t
           ib = Math.cos(ir) * (kMinWidthT);
         }
         else if(ix == 0){
-          ia = kMinWidthT;
+          if (iy < 0) {
+            ia = -kMinWidthT;
+          } else {
+            ia = kMinWidthT;
+          }
           ib = 0;
         }
         else{
@@ -728,7 +736,11 @@ function cdDrawCurveU(kage, polygons, x1, y1, sx1, sy1, sx2, sy2, x2, y2, ta1, t
           ib = Math.cos(ir) * kage.kMinWidthT;
         }
         else if(ix == 0){
-          ia = kage.kMinWidthT;
+          if (iy < 0) {
+            ia = -kage.kMinWidthT;
+          } else {
+            ia = kage.kMinWidthT;
+          }
           ib = 0;
         }
         else{
@@ -745,7 +757,11 @@ function cdDrawCurveU(kage, polygons, x1, y1, sx1, sy1, sx2, sy2, x2, y2, ta1, t
           ib = Math.cos(ir) * kage.kWidth;
         }
         else if(ix == 0){
-          ia = kage.kWidth;
+          if (iy < 0) {
+            ia = -kage.kWidth;
+          } else {
+            ia = kage.kWidth;
+          }
           ib = 0;
         }
         else{


### PR DESCRIPTION
こんにちは。グリフウィキの[利用者:twe](https://glyphwiki.org/wiki/User:twe)です。

一部のグリフ（特に非漢字）で上向きの筆画がある場合に、ポリゴンが自己交差するバグがあったので、修正しました。

これにより、グリフウィキのSVGで白く抜けているグリフの一部が修正されるはずです。（例えばu3090「ゐ」では下図で赤で示した画のポリゴンが自己交差していたのが修正されます。左：修正前、右：修正後）
![u3090](https://user-images.githubusercontent.com/14951262/29211597-f75d44ca-7ed4-11e7-9a7e-35e683fa546e.png)

参考までに、グリフウィキ上の最新版グリフのうち、この修正によって影響を受けるものの一覧を[グリフウィキに投稿しておきます](http://glyphwiki.org/wiki/Group:twe_%E3%82%B5%E3%83%B3%E3%83%89%E3%83%9C%E3%83%83%E3%82%AF%E3%82%B92@77)（dump_newest_only.txt の内容に基づくので、旧部品を引用していると誤判定があるかもしれません）。1100個ほどです。