### PR TITLE
左上カドのポリゴンの向きを修正

### DIFF
--- a/kagecd.js
+++ b/kagecd.js
@@ -374,7 +374,7 @@ function cdDrawCurveU(kage, polygons, x1, y1, sx1, sy1, sx2, sy2, x2, y2, ta1, t
     YY = Math.sin(rad) * v;
     
     if(a1 == 12){
-      if(x1 == x2){
+      if(x1 == sx1){
         poly= new Polygon();
         poly.push(x1 - kMinWidthT, y1);
         poly.push(x1 + kMinWidthT, y1);


### PR DESCRIPTION
This fixes the bug that a polygon for top-left corner of a curve stroke gets unintentionally turned over when first two control points of that stroke are aligned completely vertically.

曲線ストロークの頭形状を左上カドに設定した場合に、始点と中間点のX座標が揃ったときだけ左上カドにあたるポリゴンが180度回転してしまうバグを修正しました。

このパッチで修正されるバグがどのようなものかが分かる GIF 動画を下に添付します。
<img src="https://user-images.githubusercontent.com/14951262/87559992-f0f38600-c6f5-11ea-8e4d-47c2827279ee.gif" width="400">

例えば cdp-874c (@<span></span>1) では次のように赤いポリゴンの向きが修正されます。（左：修正前、右：修正後）
![image](https://user-images.githubusercontent.com/14951262/87560894-e4bbf880-c6f6-11ea-8cf0-6773dbd3f7fb.png)

他にも u2f925 (@<span></span>10) や u671b-v01 (@<span></span>1) などでも同様の問題が修正されます。