### PR TITLE
交差判定に乙線の後半を含める

### DIFF
--- a/2d.js
+++ b/2d.js
@@ -68,6 +68,7 @@ function isCrossBoxWithOthers(strokesArray, i, bx1, by1, bx2, by2){ // boolean
     case 2:
     case 12:
     case 3:
+    case 4:
       if(isCrossBox(strokesArray[j][5],
                     strokesArray[j][6],
                     strokesArray[j][7],
@@ -108,6 +109,7 @@ function isCrossWithOthers(strokesArray, i, bx1, by1, bx2, by2){ // boolean
     case 2:
     case 12:
     case 3:
+    case 4:
       if(isCross(strokesArray[j][5],
                  strokesArray[j][6],
                  strokesArray[j][7],


### PR DESCRIPTION
左下・右下カドのカカトの長さの調整や、開放横画のウロコの大きさの調整で呼ばれている関数 `isCrossBoxWithOthers` と `isCrossWithOthers` で乙線への処理が抜けているために乙線の後半との交差判定がされていないことが判明しましたので、乙線に対応する`case 4:`を追加しました。

例によって修正前後で比較すると、例えば u2303d-jv@7（下図、左：修正前、右：修正後）では「田」の左右のカカトが縮み、左のカカトが乙線を突き抜けていた状態が解消します。
![image](https://user-images.githubusercontent.com/14951262/87814023-fab7ed80-c89d-11ea-9900-7f30a1a2562c.png)
